### PR TITLE
fix smartdns don't work and add nano back

### DIFF
--- a/trunk/user/Makefile
+++ b/trunk/user/Makefile
@@ -151,6 +151,7 @@ dir_$(CONFIG_FIRMWARE_INCLUDE_MENTOHUST)		+= mentohust
 dir_$(OPENSSH_ENABLED)				+= openssh
 dir_$(DROPBEAR_ENABLED)				+= dropbear
 dir_$(CONFIG_FIRMWARE_INCLUDE_HTOP)		+= htop
+dir_$(CONFIG_FIRMWARE_INCLUDE_NANO)		+= nano
 dir_$(CONFIG_FIRMWARE_INCLUDE_OPENVPN)		+= openvpn
 dir_$(CONFIG_FIRMWARE_INCLUDE_SSWAN)		+= strongswan
 dir_$(CONFIG_FIRMWARE_INCLUDE_XUPNPD)		+= xupnpd

--- a/trunk/user/smartdns/smartdns.sh
+++ b/trunk/user/smartdns/smartdns.sh
@@ -445,7 +445,7 @@ Start_smartdns () {
     fi
     # 通过检测配置文件是否变化，确定是否重启 dnsmasq 进程
     if [ "$dnsmasq_md5" != $(md5sum  "$dnsmasq_Conf" | awk '{ print $1 }') ] ; then
-         /sbin/restart_dns >/dev/null 2>&1
+         /sbin/restart_dhcpd >/dev/null 2>&1
     fi
     # 启动 smartdns 进程
     "$smartdns_Bin" -f -c "$smartdns_Conf" "$args"  &>/dev/null &
@@ -471,7 +471,7 @@ Start_smartdns () {
         action="stop"
         Stop_smartdns
         if [ "$dnsmasq_md5" != $(md5sum  "$dnsmasq_Conf" | awk '{ print $1 }') ] ; then
-             /sbin/restart_dns >/dev/null 2>&1
+             /sbin/restart_dhcpd >/dev/null 2>&1
         fi
         exit
     else
@@ -488,7 +488,7 @@ Stop_smartdns () {
     Change_dnsmasq
     Change_iptable
     if [ "$dnsmasq_md5" != $(md5sum  "$dnsmasq_Conf" | awk '{ print $1 }') ] && [ "$sdns_enable" = 0 ] ; then
-         /sbin/restart_dns >/dev/null 2>&1
+         /sbin/restart_dhcpd >/dev/null 2>&1
     fi
     smartdns_process=$(pidof smartdns | awk '{ print $1 }')
     if [ "$smartdns_process"x = x ] && [ "$sdns_enable" = 0 ] ; then 


### PR DESCRIPTION
restart_dns不能正确让dnsmasq调用加进去的本机smartdns 改回以前用的restart_dhcpd 可以了
把nano加回makefile了