### PR TITLE
fix: print pSsid from array instead of pointer;

### DIFF
--- a/trunk/linux-4.4.x/drivers/net/wireless/mediatek/mt7615/embedded/common/rrm.c
+++ b/trunk/linux-4.4.x/drivers/net/wireless/mediatek/mt7615/embedded/common/rrm.c
@@ -739,7 +739,7 @@ VOID RRM_PeerNeighborReqAction(
 			MTWF_LOG(DBG_CAT_PROTO, CATPROTO_RRM, DBG_LVL_TRACE, ("DialogToken=%x\n", DialogToken));
 			snprintf(ssidbuf, sizeof(ssidbuf), "%s", pSsid);
 			ssidbuf[SsidLen] = '\0';
-			MTWF_LOG(DBG_CAT_PROTO, CATPROTO_RRM, DBG_LVL_ERROR, ("pSsid=%s\n", pSsid));
+			MTWF_LOG(DBG_CAT_PROTO, CATPROTO_RRM, DBG_LVL_ERROR, ("pSsid=%s\n", /*pSsid*/ssidbuf));
 			MTWF_LOG(DBG_CAT_PROTO, CATPROTO_RRM, DBG_LVL_TRACE, ("SsidLen=%d\n", SsidLen));
 			RRM_EnqueueNeighborRep(pAd, pEntry, DialogToken, pSsid, SsidLen);
 		}

--- a/trunk/linux-4.4.x/drivers/net/wireless/mediatek/mt76x2/common/rrm.c
+++ b/trunk/linux-4.4.x/drivers/net/wireless/mediatek/mt76x2/common/rrm.c
@@ -579,6 +579,7 @@ VOID RRM_PeerNeighborReqAction(
 	PMAC_TABLE_ENTRY pEntry;
 	UINT8 DialogToken;
 	PCHAR pSsid = NULL;
+	CHAR ssidbuf[MAX_LEN_OF_SSID+1];
 	UINT8 SsidLen = 0;
 
 	DBGPRINT(RT_DEBUG_TRACE, ("%s::\n", __FUNCTION__));
@@ -593,7 +594,9 @@ VOID RRM_PeerNeighborReqAction(
 	if (RRM_PeerNeighborReqSanity(pAd, Elem->Msg, Elem->MsgLen, &DialogToken, &pSsid, &SsidLen))
 	{
 		DBGPRINT(RT_DEBUG_TRACE, ("DialogToken=%x\n", DialogToken));
-		DBGPRINT(RT_DEBUG_TRACE, ("pSsid=%s\n", pSsid));
+		snprintf(ssidbuf, sizeof(ssidbuf), "%s", pSsid);
+		ssidbuf[SsidLen] = '\0';
+		DBGPRINT(RT_DEBUG_TRACE, ("pSsid=%s\n", /*pSsid*/ssidbuf));
 		DBGPRINT(RT_DEBUG_TRACE, ("SsidLen=%d\n", SsidLen));
 		RRM_EnqueueNeighborRep(pAd, pEntry, DialogToken, pSsid, SsidLen);
 	}


### PR DESCRIPTION
修复日志中的 pSsid=%s 的乱码