### PR TITLE
use ipv6 global unicast address cc00:101:101::/64 as ipv6 nat address

### DIFF
--- a/trunk/user/rc/firewall_ex.c
+++ b/trunk/user/rc/firewall_ex.c
@@ -1728,7 +1728,7 @@ ip6t_nat_rules(char *man_if)
 	fprintf(fp, ":%s %s [0:0]\n", "INPUT", "ACCEPT");
 	fprintf(fp, ":%s %s [0:0]\n", "OUTPUT", "ACCEPT");
 	fprintf(fp, ":%s %s [0:0]\n", "POSTROUTING", "ACCEPT");
-	fprintf(fp, "-A POSTROUTING -s fc00:101:101::1/64 -j FULLCONENAT\n");
+	fprintf(fp, "-A POSTROUTING -s cc00:101:101::1/64 -j FULLCONENAT\n");
 	fprintf(fp, "COMMIT\n\n");
 	fclose(fp);
 		doSystem("ip6tables-restore %s", ipt_file);

--- a/trunk/user/shared/defaults.c
+++ b/trunk/user/shared/defaults.c
@@ -442,7 +442,7 @@ struct nvram_pair router_defaults[] = {
 	{ "ip6_dns3", "" },
 
 	{ "ip6_lan_auto", "0" },
-	{ "ip6_lan_addr", "fc00:101:101::1" },
+	{ "ip6_lan_addr", "cc00:101:101::1" },
 	{ "ip6_lan_size", "64" },
 	{ "ip6_lan_radv", "1" },
 	{ "ip6_lan_dhcp", "1" },


### PR DESCRIPTION
Currently we use IPV6 unique local address(ULA) `fc00:101:101::/64` as out ipv6 NAT address. However, some OSs(i.e. Android) or programs prefer IPV4 address to IPV6 ULA for dual stack domain connection.

The priority for these OSs and programs is `IPV6 global unicast address > IPV4 > IPV6 unique local address`.

Using an IPV6 unique local address as NAT address can force these OSs to use IPv6 for dual stack domain, which solves the problem.

This PR change `fc00:101:101::/64` to `cc00:101:101::/64`. This address block isn't allocated by IANA so it is safe to use it here.