### PR TITLE
Update jcg-q20.dts

### DIFF
--- a/trunk/linux-4.4.x/arch/mips/boot/dts/ralink/jcg-q20.dts
+++ b/trunk/linux-4.4.x/arch/mips/boot/dts/ralink/jcg-q20.dts
@@ -78,28 +78,18 @@
 			};
 
 			partition@180000 {
-				label = "Crash";
-				reg = <0x180000 0x80000>; /* 512k */
-			};
-
-			partition@200000 {
 				label = "firmware";
-				reg = <0x200000 0x1800000>; /* 24M */
+				reg = <0x180000 0x1800000>;	/* 24M */
 			};
 
-			partition@1a00000 {
-				label = "Config";
-				reg = <0x1a00000 0x80000>; /* 512K */
-			};
-
-			partition@1a80000 {
+			partition@1980000 {
 				label = "Storage";
-				reg = <0x1a80000 0x400000>; /* 4096K */
+				reg = <0x1980000 0x400000>; /* 4096K */
 			};
 
-			partition@1e80000 {
+			partition@1d80000 {
 				label = "RWFS";
-				reg = <0x1e80000 0x6100000>;
+				reg = <0x1d80000 0x6200000>;
 			};
 
 			partition@all {


### PR DESCRIPTION
I use newest jcg-q20.dts to compile firmware, but device can't boot correctly.
My device is stock mtd. After I edit this file back to hanwckf version, it works properly.

stock mtd information
![image](https://github.com/MeIsReallyBa/padavan-4.4/assets/71462016/1d639499-bffd-4680-a003-2e8fc917ce3e)
