### PR TITLE
fix mtd layout for jdcloud-re-sp-01b

### DIFF
--- a/trunk/linux-4.4.x/arch/mips/boot/dts/ralink/jdcloud-re-sp-01b.dts
+++ b/trunk/linux-4.4.x/arch/mips/boot/dts/ralink/jdcloud-re-sp-01b.dts
@@ -2,7 +2,6 @@
 
 #include "mt7621.dtsi"
 #include <dt-bindings/input/input.h>
-#include "mt7621-spi-32m-layout.dtsi"
 #include "mt7621-raeth-gmac2.dtsi"
 #include "mt7621-pinctrl-default-gpio.dtsi"
 
@@ -45,6 +44,54 @@
 			linux,code = <KEY_RESTART>;
 		};
 
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+		m25p,fast-read;
+
+		partition@0 {
+			label = "Bootloader";
+			reg = <0x00000 0x30000>; /* 192K */
+		};
+
+		partition@30000 {
+			label = "Reserved";
+			reg = <0x30000 0x10000>; /* 64K */
+		};
+
+		partition@40000 {
+			label = "Factory";
+			reg = <0x40000 0x10000>; /* 64K */
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0x1f20000>;
+		};
+
+		partition@1f70000 {
+			label = "Config";
+			reg = <0x1f70000 0x10000>;
+		};
+
+		partition@1f80000 {
+			label = "Storage";
+			reg = <0x1f80000 0x80000>; /* 512K */
+		};
+
+		partition@all {
+			label = "ALL";
+			reg = <0x0 0x2000000>;
+		};
 	};
 };
 


### PR DESCRIPTION
原厂Config分区保存了机器的MAC，我们不能把这个分区作为padavan的config分区，否则会把原厂mac信息覆盖掉，这个PR修改了分区布局，将配置分区放到了固件下方以解决问题